### PR TITLE
Respect built-in pipe escaping

### DIFF
--- a/integraality/pages_processor.py
+++ b/integraality/pages_processor.py
@@ -51,7 +51,7 @@ class PagesProcessor:
     def extract_elements_from_template_param(template_param):
         """Extract and sanitize the contents of a parsed template param."""
         (field, _, value) = template_param.partition(u'=')
-        return (field.strip(), value)
+        return (field.strip(), value.replace('{{!}}', '|'))
 
     def parse_config_from_params(self, params):
         return {

--- a/integraality/tests/test_pages_processor.py
+++ b/integraality/tests/test_pages_processor.py
@@ -158,6 +158,16 @@ class TestParseParams(ProcessortTest):
         result = self.processor.parse_config_from_params(params)
         self.assertEqual(result, expected)
 
+    def test_parse_config_from_params_with_escsped_pipe(self):
+        params = ['', 'grouping_property=P195', 'properties=P170:creator,P276', 'selector_sparql=REGEX(?id, "^(a{{!}}b)")']
+        expected = {
+            'grouping_property': 'P195',
+            'properties': 'P170:creator,P276',
+            'selector_sparql': 'REGEX(?id, "^(a|b)")'
+        }
+        result = self.processor.parse_config_from_params(params)
+        self.assertEqual(result, expected)
+
 
 class TestParseConfigProperties(ProcessortTest):
 

--- a/integraality/tests/test_pages_processor.py
+++ b/integraality/tests/test_pages_processor.py
@@ -158,7 +158,7 @@ class TestParseParams(ProcessortTest):
         result = self.processor.parse_config_from_params(params)
         self.assertEqual(result, expected)
 
-    def test_parse_config_from_params_with_escsped_pipe(self):
+    def test_parse_config_from_params_with_escaped_pipe(self):
         params = ['grouping_property=P195', 'properties=P170:creator,P276',
                   'selector_sparql=REGEX(?id, "^(a{{!}}b)")']
         expected = {

--- a/integraality/tests/test_pages_processor.py
+++ b/integraality/tests/test_pages_processor.py
@@ -159,7 +159,8 @@ class TestParseParams(ProcessortTest):
         self.assertEqual(result, expected)
 
     def test_parse_config_from_params_with_escsped_pipe(self):
-        params = ['', 'grouping_property=P195', 'properties=P170:creator,P276', 'selector_sparql=REGEX(?id, "^(a{{!}}b)")']
+        params = ['grouping_property=P195', 'properties=P170:creator,P276',
+                  'selector_sparql=REGEX(?id, "^(a{{!}}b)")']
         expected = {
             'grouping_property': 'P195',
             'properties': 'P170:creator,P276',


### PR DESCRIPTION
MediaWiki has built in escaping of `|`-characters using
`{{!}}`. So handle these as part of sanitization.

Bug: [T237187](https://phabricator.wikimedia.org/T237187)