### PR TITLE
Output property for "No grouping" cells

### DIFF
--- a/integraality/property_statistics.py
+++ b/integraality/property_statistics.py
@@ -364,7 +364,7 @@ SELECT (COUNT(?item) as ?count) WHERE {{
             else:
                 propcount = self.get_property_info_no_grouping(property_name)
             percentage = self._get_percentage(propcount, total_no_count)
-            text += f('| {{{{{self.cell_template}|{percentage}|{propcount}}}}}\n')
+            text += f('| {{{{{self.cell_template}|{percentage}|{propcount}|property={prop_entry.property}}}}}\n')  # noqa
         return text
 
     def make_stats_for_one_grouping(self, grouping, item_count, higher_grouping):

--- a/integraality/tests/test_property_statistics.py
+++ b/integraality/tests/test_property_statistics.py
@@ -104,10 +104,10 @@ class MakeStatsForNoGroupTest(PropertyStatisticsTest):
             "|-\n"
             "| No grouping \n"
             "| 20 \n"
-            "| {{Integraality cell|10.0|2}}\n"
-            "| {{Integraality cell|50.0|10}}\n"
-            "| {{Integraality cell|75.0|15}}\n"
-            "| {{Integraality cell|25.0|5}}\n"
+            "| {{Integraality cell|10.0|2|property=P21}}\n"
+            "| {{Integraality cell|50.0|10|property=P19}}\n"
+            "| {{Integraality cell|75.0|15|property=P1}}\n"
+            "| {{Integraality cell|25.0|5|property=P3}}\n"
         )
         self.assertEqual(result, expected)
         self.mock_get_totals_no_grouping.assert_called_once_with(self.stats)
@@ -131,10 +131,10 @@ class MakeStatsForNoGroupTest(PropertyStatisticsTest):
             "|\n"
             "| No grouping \n"
             "| 20 \n"
-            "| {{Integraality cell|10.0|2}}\n"
-            "| {{Integraality cell|50.0|10}}\n"
-            "| {{Integraality cell|75.0|15}}\n"
-            "| {{Integraality cell|25.0|5}}\n"
+            "| {{Integraality cell|10.0|2|property=P21}}\n"
+            "| {{Integraality cell|50.0|10|property=P19}}\n"
+            "| {{Integraality cell|75.0|15|property=P1}}\n"
+            "| {{Integraality cell|25.0|5|property=P3}}\n"
         )
         self.assertEqual(result, expected)
         self.mock_get_totals_no_grouping.assert_called_once_with(self.stats)


### PR DESCRIPTION
The parameter is needed to trigger the correct query links.

Bug: [T237182](https://phabricator.wikimedia.org/T237182)