### PR TITLE
Adapt queries to handle 'totals' use-case

### DIFF
--- a/integraality/app.py
+++ b/integraality/app.py
@@ -33,10 +33,13 @@ def update():
 def queries():
     page = request.args.get('page')
     property = request.args.get('property')
-    grouping = request.args.get('grouping')
     processor = PagesProcessor()
     try:
         stats = processor.make_stats_object_for_page_title(page)
+        try:
+            grouping = stats.GROUP_MAPPING(request.args.get('grouping'))
+        except KeyError:
+            grouping = request.args.get('grouping')
         positive_query = stats.get_query_for_items_for_property_positive(property, grouping)
         negative_query = stats.get_query_for_items_for_property_negative(property, grouping)
         return render_template('queries.html', page=page, property=property, grouping=grouping,

--- a/integraality/property_statistics.py
+++ b/integraality/property_statistics.py
@@ -50,7 +50,7 @@ class PropertyStatistics:
     Generate statitics
 
     """
-    GROUP_MAPPING = Enum('GROUP_MAPPING', {'NO_GROUPING': 'None'})
+    GROUP_MAPPING = Enum('GROUP_MAPPING', {'NO_GROUPING': 'None', 'TOTALS': ''})
 
     def __init__(self, selector_sparql, properties, grouping_property, higher_grouping=None, higher_grouping_type=None, stats_for_no_group=False, grouping_link=None, grouping_threshold=20, property_threshold=0):  # noqa
         """
@@ -125,7 +125,10 @@ LIMIT 1000
 SELECT DISTINCT ?entity ?entityLabel ?value ?valueLabel WHERE {{
   ?entity {self.selector_sparql} .""")
 
-        if grouping == self.GROUP_MAPPING.NO_GROUPING:
+        if grouping == self.GROUP_MAPPING.TOTALS:
+            pass
+
+        elif grouping == self.GROUP_MAPPING.NO_GROUPING:
             query += f("""
   MINUS {{
     ?entity wdt:{self.grouping_property} [] .
@@ -146,7 +149,11 @@ SELECT DISTINCT ?entity ?entityLabel ?value ?valueLabel WHERE {{
 SELECT DISTINCT ?entity ?entityLabel WHERE {{
   ?entity {self.selector_sparql} .""")
 
-        if grouping == self.GROUP_MAPPING.NO_GROUPING:
+        if grouping == self.GROUP_MAPPING.TOTALS:
+            query += f("""
+  MINUS {{""")
+
+        elif grouping == self.GROUP_MAPPING.NO_GROUPING:
             query += f("""
   MINUS {{
     {{?entity wdt:{self.grouping_property} [] .}} UNION""")
@@ -437,7 +444,7 @@ SELECT (COUNT(?item) as ?count) WHERE {{
             else:
                 totalprop = self.get_totals_for_property(property=property_name)
             percentage = self._get_percentage(totalprop, total_items)
-            text += f('| {{{{{self.cell_template}|{percentage}|{totalprop}}}}}\n')
+            text += f('| {{{{{self.cell_template}|{percentage}|{totalprop}|property={prop_entry.property}}}}}\n')
         text += u'|}\n'
         return text
 

--- a/integraality/tests/test_app.py
+++ b/integraality/tests/test_app.py
@@ -80,14 +80,18 @@ class QueriesTests(PagesProcessorTests):
 
     def setUp(self):
         super().setUp()
-        patcher = patch('pages_processor.PropertyStatistics', autospec=True)
-        self.mock_property_statistics = patcher.start()
-        self.addCleanup(patcher.stop)
+        patcher1 = patch('pages_processor.PropertyStatistics', autospec=True)
+        self.mock_property_statistics = patcher1.start()
+        self.addCleanup(patcher1.stop)
+        patcher2 = patch('pages_processor.PropertyStatistics.GROUP_MAPPING', autospec=True)
+        self.mock_group_mapping = patcher2.start()
+        self.addCleanup(patcher2.stop)
 
     def test_queries_success(self):
         self.mock_pages_processor.return_value.make_stats_object_for_page_title.return_value = self.mock_property_statistics  # noqa
         self.mock_property_statistics.get_query_for_items_for_property_positive.return_value = "X"
         self.mock_property_statistics.get_query_for_items_for_property_negative.return_value = "Z"
+        self.mock_group_mapping.side_effect = KeyError
         response = self.app.get('/queries?page=%s&property=P1&grouping=Q2' % self.page_title)
         self.mock_pages_processor.assert_called_once_with()
         self.mock_pages_processor.return_value.make_stats_object_for_page_title.assert_called_once_with(page_title=self.page_title)  # noqa

--- a/integraality/tests/test_property_statistics.py
+++ b/integraality/tests/test_property_statistics.py
@@ -104,10 +104,10 @@ class MakeStatsForNoGroupTest(PropertyStatisticsTest):
             "|-\n"
             "| No grouping \n"
             "| 20 \n"
-            "| {{Integraality cell|10.0|2|property=P21}}\n"
-            "| {{Integraality cell|50.0|10|property=P19}}\n"
-            "| {{Integraality cell|75.0|15|property=P1}}\n"
-            "| {{Integraality cell|25.0|5|property=P3}}\n"
+            "| {{Integraality cell|10.0|2|property=P21|grouping=None}}\n"
+            "| {{Integraality cell|50.0|10|property=P19|grouping=None}}\n"
+            "| {{Integraality cell|75.0|15|property=P1|grouping=None}}\n"
+            "| {{Integraality cell|25.0|5|property=P3|grouping=None}}\n"
         )
         self.assertEqual(result, expected)
         self.mock_get_totals_no_grouping.assert_called_once_with(self.stats)
@@ -131,10 +131,10 @@ class MakeStatsForNoGroupTest(PropertyStatisticsTest):
             "|\n"
             "| No grouping \n"
             "| 20 \n"
-            "| {{Integraality cell|10.0|2|property=P21}}\n"
-            "| {{Integraality cell|50.0|10|property=P19}}\n"
-            "| {{Integraality cell|75.0|15|property=P1}}\n"
-            "| {{Integraality cell|25.0|5|property=P3}}\n"
+            "| {{Integraality cell|10.0|2|property=P21|grouping=None}}\n"
+            "| {{Integraality cell|50.0|10|property=P19|grouping=None}}\n"
+            "| {{Integraality cell|75.0|15|property=P1|grouping=None}}\n"
+            "| {{Integraality cell|25.0|5|property=P3|grouping=None}}\n"
         )
         self.assertEqual(result, expected)
         self.mock_get_totals_no_grouping.assert_called_once_with(self.stats)
@@ -219,7 +219,7 @@ SELECT DISTINCT ?entity ?entityLabel ?value ?valueLabel WHERE {
         self.assertEqual(result, expected)
 
     def test_get_query_for_items_for_property_positive_no_grouping(self):
-        result = self.stats.get_query_for_items_for_property_positive('P21', '')
+        result = self.stats.get_query_for_items_for_property_positive('P21', self.stats.GROUP_MAPPING.NO_GROUPING)
         expected = """
 SELECT DISTINCT ?entity ?entityLabel ?value ?valueLabel WHERE {
   ?entity wdt:P31 wd:Q41960 .
@@ -251,7 +251,7 @@ SELECT DISTINCT ?entity ?entityLabel WHERE {
         self.assertEqual(result, expected)
 
     def test_get_query_for_items_for_property_negative_no_grouping(self):
-        result = self.stats.get_query_for_items_for_property_negative('P21', '')
+        result = self.stats.get_query_for_items_for_property_negative('P21', self.stats.GROUP_MAPPING.NO_GROUPING)
         expected = """
 SELECT DISTINCT ?entity ?entityLabel WHERE {
   ?entity wdt:P31 wd:Q41960 .

--- a/integraality/tests/test_property_statistics.py
+++ b/integraality/tests/test_property_statistics.py
@@ -232,6 +232,17 @@ SELECT DISTINCT ?entity ?entityLabel ?value ?valueLabel WHERE {
 """
         self.assertEqual(result, expected)
 
+    def test_get_query_for_items_for_property_positive_totals(self):
+        result = self.stats.get_query_for_items_for_property_positive('P21', self.stats.GROUP_MAPPING.TOTALS)
+        expected = """
+SELECT DISTINCT ?entity ?entityLabel ?value ?valueLabel WHERE {
+  ?entity wdt:P31 wd:Q41960 .
+  ?entity p:P21 ?prop . OPTIONAL { ?prop ps:P21 ?value }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}
+"""
+        self.assertEqual(result, expected)
+
 
 class GetQueryForItemsForPropertyNegative(PropertyStatisticsTest):
 
@@ -257,6 +268,20 @@ SELECT DISTINCT ?entity ?entityLabel WHERE {
   ?entity wdt:P31 wd:Q41960 .
   MINUS {
     {?entity wdt:P551 [] .} UNION
+    {?entity a wdno:P21 .} UNION
+    {?entity wdt:P21 ?prop .}
+  }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}
+"""
+        self.assertEqual(result, expected)
+
+    def test_get_query_for_items_for_property_negative_totals(self):
+        result = self.stats.get_query_for_items_for_property_negative('P21', self.stats.GROUP_MAPPING.TOTALS)
+        expected = """
+SELECT DISTINCT ?entity ?entityLabel WHERE {
+  ?entity wdt:P31 wd:Q41960 .
+  MINUS {
     {?entity a wdno:P21 .} UNION
     {?entity wdt:P21 ?prop .}
   }
@@ -607,10 +632,10 @@ class MakeFooterTest(SparqlQueryTest):
             '|- class="sortbottom"\n'
             "|\'\'\'Totals\'\'\' <small>(all items)</small>:\n"
             "| 120\n"
-            "| {{Integraality cell|25.0|30}}\n"
-            "| {{Integraality cell|66.67|80}}\n"
-            "| {{Integraality cell|8.33|10}}\n"
-            "| {{Integraality cell|10.0|12}}\n"
+            "| {{Integraality cell|25.0|30|property=P21}}\n"
+            "| {{Integraality cell|66.67|80|property=P19}}\n"
+            "| {{Integraality cell|8.33|10|property=P1}}\n"
+            "| {{Integraality cell|10.0|12|property=P3}}\n"
             "|}\n"
         )
         self.assertEqual(result, expected)


### PR DESCRIPTION
Integraality outputs a footer with the totals per property for the collection
(covering all groupings and no-grouping).

The queries feature was not working for these - same way
as it did not work for no-grouping (fixed in 770cc9324).

- Output the property name in the wikicode
- In `get_query_for_items_X`, interpret the lack of group
  as the 'totals' use-case, and generate the (simple) query

Bug: T243998
